### PR TITLE
Clarify contents of development directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,4 @@ freefire-like-and-guest-api/
 ```
 
 - 💎 Inside the `dev/not_imp` & `dev/frida_injections/not_imp/` there are my all works, the scripts, methods i used to create this repository. It's more than a diamond if you can understand what those things are for.
+ 


### PR DESCRIPTION
Added a note about the contents of the 'dev/not_imp' and 'dev/frida_injections/not_imp/' directories.